### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -115,7 +115,7 @@ window.addEventListener("onEventReceived", function (obj) {
   let color = data.tags.color;
   if (color === "") {
     const username = data.displayName;
-    color = data.displayColor !== "" ? data.displayColor : "#" + (md5(username).substr(26));
+    color = data.displayColor !== "" ? data.displayColor : "#" + (md5(username).slice(26));
   }
   
   addMessage(obj.detail.event.data.displayName, 


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.